### PR TITLE
add all current ROS2 releases to CI

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -8,6 +8,7 @@ jobs:
       matrix:
         env:
           - {ROS_DISTRO: humble, ROS_REPO: main}
+          - {ROS_DISTRO: jazzy, ROS_REPO: main}
           - {ROS_DISTRO: rolling, ROS_REPO: main}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -8,6 +8,7 @@ jobs:
       matrix:
         env:
           - {ROS_DISTRO: humble, ROS_REPO: main}
+          - {ROS_DISTRO: rolling, ROS_REPO: main}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This adds all current ROS2 releases (https://docs.ros.org/en/rolling/Releases.html) to the CI jobs.