### PR TITLE
make ethercat interface an argument instead of hardcoding it

### DIFF
--- a/description/ros2_control/single_dof.ros2_control.xacro
+++ b/description/ros2_control/single_dof.ros2_control.xacro
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:arg name="interface_name" default="eno0"/>
+
   <xacro:macro name="single_dof_ros2_control" params="name prefix">
 
     <ros2_control name="${name}" type="system">
@@ -10,7 +12,7 @@
         <!-- For testing, GenericSystem is much simpler and doesn't depend on the code in this package -->
         <!-- plugin>mock_components/GenericSystem</plugin -->
 
-        <param name="interface_name">eno0</param>
+        <param name="interface_name">${interface_name}</param>
       </hardware>
 
       <joint name="${prefix}joint1">

--- a/description/ros2_control/two_dof.ros2_control.xacro
+++ b/description/ros2_control/two_dof.ros2_control.xacro
@@ -1,13 +1,15 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:arg name="interface_name" default="eno0"/>
+	
   <xacro:macro name="two_dof_ros2_control" params="name prefix">
 
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>synapticon_ros2_control/SynapticonSystemInterface</plugin>
 
-        <param name="interface_name">eno0</param>
+        <param name="interface_name">${interface_name}</param>
       </hardware>
 
       <joint name="${prefix}joint1">

--- a/src/torque_control_executable.cpp
+++ b/src/torque_control_executable.cpp
@@ -260,11 +260,28 @@ OSAL_THREAD_FUNC ecatcheck(void *ptr) {
 int main(int /*argc*/, char * /*argv*/[]) {
   printf("SOEM (Simple Open EtherCAT Master)\nSimple test\n");
 
-  // create thread to handle slave error handling in OP
-  osal_thread_create(&thread1, 128000, (void *)&ecatcheck, (void *)&ctime);
-  // start cyclic part
-  const char interface_name[] = "eno0";
-  simpletest(interface_name);
+  if (argc > 1)
+  {
+      /* create thread to handle slave error handling in OP */
+//      pthread_create( &thread1, NULL, (void *) &ecatcheck, (void*) &ctime);
+      osal_thread_create(&thread1, 128000, &ecatcheck, (void*)&ctime);
+      /* start cyclic part */
+      simpletest(argv[1]);
+  }
+  else
+  {
+      printf("TODO: Add instructions on how this executable should be used. Maybe add the following example\n");
+      printf("ros2 run synapticon_ros2_control torque_control_executable -- eno0\n");
+      ec_adaptert* adapter = NULL;
+      printf("\nAvailable adapters:\n");
+      adapter = ec_find_adapters();
+      while (adapter != NULL)
+      {
+          printf("    - %s  (%s)\n", adapter->name, adapter->desc);
+          adapter = adapter->next;
+      }
+      ec_free_adapters(adapter);
+  }
 
   printf("End program\n");
   return (0);

--- a/src/torque_control_executable.cpp
+++ b/src/torque_control_executable.cpp
@@ -257,14 +257,14 @@ OSAL_THREAD_FUNC ecatcheck(void *ptr) {
   }
 }
 
-int main(int /*argc*/, char * /*argv*/[]) {
+int main(int argc, char* argv[]) {
   printf("SOEM (Simple Open EtherCAT Master)\nSimple test\n");
 
   if (argc > 1)
   {
       /* create thread to handle slave error handling in OP */
 //      pthread_create( &thread1, NULL, (void *) &ecatcheck, (void*) &ctime);
-      osal_thread_create(&thread1, 128000, &ecatcheck, (void*)&ctime);
+      osal_thread_create(&thread1, 128000, (void*)&ecatcheck, (void*)&ctime);
       /* start cyclic part */
       simpletest(argv[1]);
   }


### PR DESCRIPTION
To explain what I have done:

Firstly, torque_control_executable.cpp is a standalone executable intended for testing without ros2_control, so fixing this is easy, just revise the main function like this:

int main(int /*argc*/, char * /*argv*/[]) {
  printf("SOEM (Simple Open EtherCAT Master)\nSimple test\n");

  if (argc > 1)
  {
      /* create thread to handle slave error handling in OP */
//      pthread_create( &thread1, NULL, (void *) &ecatcheck, (void*) &ctime);
      osal_thread_create(&thread1, 128000, &ecatcheck, (void*)&ctime);
      /* start cyclic part */
      simpletest(argv[1]);
  }
  else
  {
      printf("TODO: Add instructions on how this executable should be used. Maybe add the following example\n");
      printf("ros2 run synapticon_ros2_control torque_control_executable -- eno0\n");
      ec_adaptert* adapter = NULL;
      printf("\nAvailable adapters:\n");
      adapter = ec_find_adapters();
      while (adapter != NULL)
      {
          printf("    - %s  (%s)\n", adapter->name, adapter->desc);
          adapter = adapter->next;
      }
      ec_free_adapters(adapter);
  }

  printf("End program\n");
  return (0);
}

Please do note this sentence and revise it.
printf("TODO: Add instructions on how this executable should be used. Maybe add the following example\n");

Then when running the executable after building, you need to explicitly input your adapter name (eno0 for example) like this: ros2 run synapticon_ros2_control torque_control_executable -- eno0

As for the synapticon_interface related to ros2_control, my idea is to make the interface_name defined in the two xacro files become arguments.

To do that, we can add this
<xacro:arg name="interface_name" default="eno0"/>
And then replace this
<param name="interface_name">eno0</param>
with this
<param name="interface_name">${interface_name}</param>

After this, we just need to revise the launch files in the bringup folder to accept an argument, which is then passed as the argument for the xacro file. I forgot how to do that so I just told GPT my request and let it do the job. Also, I only revised single_dof.launch.py as an initial test.

Then when running the launch file after building, you need to explicitly input your adapter name (eno0 for example) like this: ros2 launch synapticon_ros2_control single_dof.launch.py interface_name:=eno0