### PR TITLE
Feature/ethernet device as parameter

### DIFF
--- a/bringup/launch/single_dof.launch.py
+++ b/bringup/launch/single_dof.launch.py
@@ -99,7 +99,7 @@ def generate_launch_description():
         ],
     )
 
-    # Delay event handlers for starting nodes in order
+    # Delay rviz start after `joint_state_broadcaster`
     delay_rviz_after_joint_state_broadcaster_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
@@ -107,10 +107,14 @@ def generate_launch_description():
         )
     )
 
-    delay_joint_state_broadcaster_after_inactive_controller_spawner = RegisterEventHandler(
-        event_handler=OnProcessExit(
-            target_action=inactive_controller_spawner,
-            on_exit=[joint_state_broadcaster_spawner],
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_inactive_controller_spawner = (
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=inactive_controller_spawner,
+                on_exit=[joint_state_broadcaster_spawner],
+            )
         )
     )
 

--- a/bringup/launch/single_dof.launch.py
+++ b/bringup/launch/single_dof.launch.py
@@ -12,7 +12,7 @@ from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
-    # Declare launch arguments, including one for the interface name
+    # Declare launch arguments, including one for the ethernet device name
     declared_arguments = []
     declared_arguments.append(
         DeclareLaunchArgument(
@@ -23,17 +23,17 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "interface_name",
+            "eth_device",
             default_value="eno0",
-            description="Ethernet interface name (e.g., eno0, eth0)",
+            description="Ethernet device name (e.g., eno0, eth0)",
         )
     )
 
     # Initialize LaunchConfigurations
     gui = LaunchConfiguration("gui")
-    interface_name = LaunchConfiguration("interface_name")
+    eth_device = LaunchConfiguration("eth_device")
 
-    # Get URDF via xacro, passing the interface_name argument
+    # Get URDF via xacro, passing the eth_device argument
     robot_description_content = Command(
         [
             PathJoinSubstitution([FindExecutable(name="xacro")]),
@@ -45,8 +45,8 @@ def generate_launch_description():
                     "single_dof_in_world.urdf.xacro",
                 ]
             ),
-            " interface_name:=",
-            interface_name,
+            " eth_device:=",
+            eth_device,
         ]
     )
     robot_description = {"robot_description": robot_description_content}

--- a/bringup/launch/two_dof.launch.py
+++ b/bringup/launch/two_dof.launch.py
@@ -12,7 +12,7 @@ from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
-    # Declare launch arguments, including one for the interface name
+    # Declare launch arguments, including one for the ethernet device name
     declared_arguments = []
     declared_arguments.append(
         DeclareLaunchArgument(
@@ -23,17 +23,17 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "interface_name",
+            "eth_device",
             default_value="eno0",
-            description="Ethernet interface name (e.g., eno0, eth0)",
+            description="Ethernet device name (e.g., eno0, eth0)",
         )
     )
 
     # Initialize LaunchConfigurations
     gui = LaunchConfiguration("gui")
-    interface_name = LaunchConfiguration("interface_name")
+    eth_device = LaunchConfiguration("eth_device")
 
-    # Get URDF via xacro, passing the interface_name argument
+    # Get URDF via xacro, passing the eth_device argument
     robot_description_content = Command(
         [
             PathJoinSubstitution([FindExecutable(name="xacro")]),
@@ -45,8 +45,8 @@ def generate_launch_description():
                     "two_dof_in_world.urdf.xacro",
                 ]
             ),
-            " interface_name:=",
-            interface_name,
+            " eth_device:=",
+            eth_device,
         ]
     )
     robot_description = {"robot_description": robot_description_content}

--- a/bringup/launch/two_dof.launch.py
+++ b/bringup/launch/two_dof.launch.py
@@ -8,13 +8,11 @@ from launch.substitutions import (
     LaunchConfiguration,
     PathJoinSubstitution,
 )
-
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
-
 def generate_launch_description():
-    # Declare arguments
+    # Declare launch arguments, including one for the interface name
     declared_arguments = []
     declared_arguments.append(
         DeclareLaunchArgument(
@@ -23,11 +21,19 @@ def generate_launch_description():
             description="Start RViz2 automatically with this launch file.",
         )
     )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "interface_name",
+            default_value="eno0",
+            description="Ethernet interface name (e.g., eno0, eth0)",
+        )
+    )
 
-    # Initialize Arguments
+    # Initialize LaunchConfigurations
     gui = LaunchConfiguration("gui")
+    interface_name = LaunchConfiguration("interface_name")
 
-    # Get URDF via xacro
+    # Get URDF via xacro, passing the interface_name argument
     robot_description_content = Command(
         [
             PathJoinSubstitution([FindExecutable(name="xacro")]),
@@ -39,10 +45,13 @@ def generate_launch_description():
                     "two_dof_in_world.urdf.xacro",
                 ]
             ),
+            " interface_name:=",
+            interface_name,
         ]
     )
     robot_description = {"robot_description": robot_description_content}
 
+    # Other configurations (controllers, rviz config, etc.)
     robot_controllers = PathJoinSubstitution(
         [
             FindPackageShare("synapticon_ros2_control"),
@@ -50,7 +59,6 @@ def generate_launch_description():
             "two_dof_controllers.yaml",
         ]
     )
-
     rviz_config_file = PathJoinSubstitution(
         [FindPackageShare("synapticon_ros2_control"), "config", "two_dof.rviz"]
     )

--- a/description/ros2_control/single_dof.ros2_control.xacro
+++ b/description/ros2_control/single_dof.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="single_dof_ros2_control" params="name prefix interface_name">
+  <xacro:macro name="single_dof_ros2_control" params="name prefix eth_device">
 
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>synapticon_ros2_control/SynapticonSystemInterface</plugin>
 
-        <param name="interface_name">${interface_name}</param>
+        <param name="eth_device">${eth_device}</param>
       </hardware>
 
       <joint name="${prefix}joint1">

--- a/description/ros2_control/single_dof.ros2_control.xacro
+++ b/description/ros2_control/single_dof.ros2_control.xacro
@@ -1,16 +1,11 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:arg name="interface_name" default="eno0"/>
-
-  <xacro:macro name="single_dof_ros2_control" params="name prefix">
+  <xacro:macro name="single_dof_ros2_control" params="name prefix interface_name">
 
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>synapticon_ros2_control/SynapticonSystemInterface</plugin>
-
-        <!-- For testing, GenericSystem is much simpler and doesn't depend on the code in this package -->
-        <!-- plugin>mock_components/GenericSystem</plugin -->
 
         <param name="interface_name">${interface_name}</param>
       </hardware>

--- a/description/ros2_control/two_dof.ros2_control.xacro
+++ b/description/ros2_control/two_dof.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="two_dof_ros2_control" params="name prefix interface_name">
+  <xacro:macro name="two_dof_ros2_control" params="name prefix eth_device">
 
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>synapticon_ros2_control/SynapticonSystemInterface</plugin>
 
-        <param name="interface_name">${interface_name}</param>
+        <param name="eth_device">${eth_device}</param>
       </hardware>
 
       <joint name="${prefix}joint1">

--- a/description/ros2_control/two_dof.ros2_control.xacro
+++ b/description/ros2_control/two_dof.ros2_control.xacro
@@ -1,9 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:arg name="interface_name" default="eno0"/>
-	
-  <xacro:macro name="two_dof_ros2_control" params="name prefix">
+  <xacro:macro name="two_dof_ros2_control" params="name prefix interface_name">
 
     <ros2_control name="${name}" type="system">
       <hardware>

--- a/description/urdf/single_dof_in_world.urdf.xacro
+++ b/description/urdf/single_dof_in_world.urdf.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="single_dof">
   <xacro:arg name="prefix" default="" />
+  <xacro:arg name="interface_name" default="" />
 
   <xacro:include filename="$(find synapticon_ros2_control)/urdf/single_dof_macro.urdf.xacro" />
 
@@ -12,6 +13,6 @@
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:single_dof>
 
-  <xacro:single_dof_ros2_control name="SingleDofRos2Control" prefix="$(arg prefix)" />
+  <xacro:single_dof_ros2_control name="SingleDofRos2Control" prefix="$(arg prefix)" interface_name="$(arg interface_name)" />
 
 </robot>

--- a/description/urdf/single_dof_in_world.urdf.xacro
+++ b/description/urdf/single_dof_in_world.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="single_dof">
   <xacro:arg name="prefix" default="" />
-  <xacro:arg name="interface_name" default="" />
+  <xacro:arg name="eth_device" default="" />
 
   <xacro:include filename="$(find synapticon_ros2_control)/urdf/single_dof_macro.urdf.xacro" />
 
@@ -13,6 +13,6 @@
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:single_dof>
 
-  <xacro:single_dof_ros2_control name="SingleDofRos2Control" prefix="$(arg prefix)" interface_name="$(arg interface_name)" />
+  <xacro:single_dof_ros2_control name="SingleDofRos2Control" prefix="$(arg prefix)" eth_device="$(arg eth_device)" />
 
 </robot>

--- a/description/urdf/two_dof_in_world.urdf.xacro
+++ b/description/urdf/two_dof_in_world.urdf.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="two_dof">
   <xacro:arg name="prefix" default="" />
+  <xacro:arg name="interface_name" default="" />
 
   <xacro:include filename="$(find synapticon_ros2_control)/urdf/two_dof_macro.urdf.xacro" />
 
@@ -12,6 +13,6 @@
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:two_dof>
 
-  <xacro:two_dof_ros2_control name="TwoDofRos2Control" prefix="$(arg prefix)" />
+  <xacro:two_dof_ros2_control name="TwoDofRos2Control" prefix="$(arg prefix)" interface_name="$(arg interface_name)" />
 
 </robot>

--- a/description/urdf/two_dof_in_world.urdf.xacro
+++ b/description/urdf/two_dof_in_world.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="two_dof">
   <xacro:arg name="prefix" default="" />
-  <xacro:arg name="interface_name" default="" />
+  <xacro:arg name="eth_device" default="" />
 
   <xacro:include filename="$(find synapticon_ros2_control)/urdf/two_dof_macro.urdf.xacro" />
 
@@ -13,6 +13,6 @@
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:two_dof>
 
-  <xacro:two_dof_ros2_control name="TwoDofRos2Control" prefix="$(arg prefix)" interface_name="$(arg interface_name)" />
+  <xacro:two_dof_ros2_control name="TwoDofRos2Control" prefix="$(arg prefix)" eth_device="$(arg eth_device)" />
 
 </robot>

--- a/src/synapticon_interface.cpp
+++ b/src/synapticon_interface.cpp
@@ -132,6 +132,7 @@ hardware_interface::CallbackReturn SynapticonSystemInterface::on_init(
   if (ec_init_status <= 0) {
     RCLCPP_FATAL_STREAM(get_logger(),
                         "Error during initialization of ethercat interface: "
+                            << interface_name.c_str() << " with status: "
                             << ec_init_status);
     return hardware_interface::CallbackReturn::ERROR;
   }

--- a/src/synapticon_interface.cpp
+++ b/src/synapticon_interface.cpp
@@ -127,12 +127,12 @@ hardware_interface::CallbackReturn SynapticonSystemInterface::on_init(
 
   // Ethercat initialization
   // Define the interface name (e.g. eth0 or eno0) in the ros2_control.xacro
-  std::string interface_name = info_.hardware_parameters["interface_name"];
-  int ec_init_status = ec_init(interface_name.c_str());
+  std::string eth_device = info_.hardware_parameters["eth_device"];
+  int ec_init_status = ec_init(eth_device.c_str());
   if (ec_init_status <= 0) {
     RCLCPP_FATAL_STREAM(get_logger(),
                         "Error during initialization of ethercat interface: "
-                            << interface_name.c_str() << " with status: "
+                            << eth_device.c_str() << " with status: "
                             << ec_init_status);
     return hardware_interface::CallbackReturn::ERROR;
   }


### PR DESCRIPTION
some fixes to https://github.com/synapticon/synapticon_ros2_control/pull/16
- fix launch arg parsing to ros2_control.xacro
- extend from single_dof to two_dof
- unify source files (emtpy lines, comments, ...) for single_dof and two_dof

I could use both examples with
```
ros2 launch synapticon_ros2_control elevated_permissions_1_dof.launch.py 
ros2 launch synapticon_ros2_control single_dof.launch.py eth_device:=YOUR_INTERFACE_NAME
```

```
ros2 launch synapticon_ros2_control elevated_permissions_2_dof.launch.py 
ros2 launch synapticon_ros2_control two_dof.launch.py eth_device:=YOUR_INTERFACE_NAME
```

using no argument will default to `eno0`.