### PR TITLE
revert runs-on setting from PR #33

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -10,11 +10,7 @@ jobs:
           - {ROS_DISTRO: humble, ROS_REPO: main}
           - {ROS_DISTRO: jazzy, ROS_REPO: main}
           - {ROS_DISTRO: rolling, ROS_REPO: main}
-        ubuntu_version:
-          - 20.04
-          - 22.04
-          - latest  # This will still include Ubuntu 24 (latest)
-    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: 'ros-industrial/industrial_ci@master'


### PR DESCRIPTION
revert runs-on setting from PR https://github.com/synapticon/synapticon_ros2_control/pull/33/ in github actions

The way #33 setup the github actions is that we'll generate and upload the docker container three times (for 20.04, 22.04, and 24.04). Depending on which build finishes last, we'll overwrite the docker image on [ghcr.io](http://ghcr.io/). This is not needed.