### PR TITLE
Deprecate ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,12 @@ target_include_directories(synapticon_ros2_control PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/oshw/${OS}>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/soem>
 )
-target_link_libraries(synapticon_ros2_control synapticon_soem)
-ament_target_dependencies(
+target_link_libraries(
   synapticon_ros2_control
-  ${THIS_PACKAGE_INCLUDE_DEPENDS}
+  hardware_interface::hardware_interface
+  pluginlib::pluginlib
+  rclcpp_lifecycle::rclcpp_lifecycle
+  synapticon_soem
 )
 
 # Export hardware plugins
@@ -68,9 +70,13 @@ pluginlib_export_plugin_description_file(hardware_interface synapticon_ros2_cont
 
 # A simple executable to test Synapticon connection without ros2_control
 add_executable(torque_control_executable src/torque_control_executable.cpp)
-target_link_libraries(torque_control_executable synapticon_soem)
-ament_target_dependencies(torque_control_executable
-                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(
+  torque_control_executable
+  hardware_interface::hardware_interface
+  pluginlib::pluginlib
+  rclcpp_lifecycle::rclcpp_lifecycle
+  synapticon_soem
+)
 
 install(
   DIRECTORY include/


### PR DESCRIPTION
I expect this will fix the build farm error for `jazzy`. It doesn't build on `humble`.

I'd suggest that we should have two branches now: `humble` and `jazzy`. This PR should be merged into `jazzy` branch.

I referred to this example when creating the PR:  https://github.com/ros-controls/ros2_controllers/blob/master/admittance_controller/CMakeLists.txt