### PR TITLE
Make ecatCheckWrapper() appear static

### DIFF
--- a/include/synapticon_ros2_control/synapticon_interface.hpp
+++ b/include/synapticon_ros2_control/synapticon_interface.hpp
@@ -110,12 +110,12 @@ public:
    */
   rclcpp::Logger get_logger() const { return *logger_; }
 
-private:
   /**
    * @brief Error checking. Typically runs in a separate thread.
    */
   OSAL_THREAD_FUNC ecatCheck(void *ptr);
 
+private:
   /**
    * @brief Somanet control loop runs in a dedicated thread
    * This steps through several states to get to Operational, if needed

--- a/src/synapticon_interface.cpp
+++ b/src/synapticon_interface.cpp
@@ -38,6 +38,12 @@ unsigned int NORMAL_OPERATION_BRAKES_OFF = 0b00001111;
 // Bit 2 (0-indexed) goes to 0 to turn on Quick Stop
 unsigned int NORMAL_OPERATION_BRAKES_ON = 0b00001011;
 constexpr char EXPECTED_SLAVE_NAME[] = "SOMANET";
+
+// This is related to making a member function appear static
+OSAL_THREAD_FUNC ecatCheckWrapper(void *ptr) {
+    SynapticonSystemInterface* interface = static_cast<SynapticonSystemInterface*>(ptr);
+    return interface->ecatCheck(ptr);
+}
 } // namespace
 
 hardware_interface::CallbackReturn SynapticonSystemInterface::on_init(
@@ -134,8 +140,8 @@ hardware_interface::CallbackReturn SynapticonSystemInterface::on_init(
 
   // A thread to handle ethercat errors
   osal_thread_create(&ecat_error_thread_, 128000,
-                     (void *)&SynapticonSystemInterface::ecatCheck,
-                     (void *)&ctime);
+                     (void*)&ecatCheckWrapper,
+                     this);
 
   // Ethercat initialization
   // Define the interface name (e.g. eth0 or eno0) in the ros2_control.xacro


### PR DESCRIPTION
On our modified fork of this repo, I was seeing a consistent segfault. Here's the fix that AI helped me come up with. Here's the explanation:

> The core problem was that a non-static C++ member function expects a hidden this pointer, but a C-style thread creation function doesn't provide one. Your ecatCheckWrapper acts as an intermediary:

    It's a C-style function that osal_thread_create can happily call.
    It receives the this pointer (of the object you want to interact with) as an explicit argument.
    It then uses that explicit this pointer to correctly call the non-static member function ecatCheck on the specific object instance.

This is the standard and correct way to launch a C++ non-static member function in a C-style thread.