### PR TITLE
Fix deprecated hardware_interface API

### DIFF
--- a/include/synapticon_ros2_control/synapticon_interface.hpp
+++ b/include/synapticon_ros2_control/synapticon_interface.hpp
@@ -81,7 +81,7 @@ public:
   ~SynapticonSystemInterface();
 
   hardware_interface::CallbackReturn
-  on_init(const hardware_interface::HardwareInfo &info) override;
+  on_init(const hardware_interface::HardwareComponentInterfaceParams &params) override;
 
   hardware_interface::return_type prepare_command_mode_switch(
       const std::vector<std::string> &start_interfaces,

--- a/src/synapticon_interface.cpp
+++ b/src/synapticon_interface.cpp
@@ -47,8 +47,8 @@ OSAL_THREAD_FUNC ecatCheckWrapper(void *ptr) {
 } // namespace
 
 hardware_interface::CallbackReturn SynapticonSystemInterface::on_init(
-    const hardware_interface::HardwareInfo &info) {
-  if (hardware_interface::SystemInterface::on_init(info) !=
+    const hardware_interface::HardwareComponentInterfaceParams &params) {
+  if (hardware_interface::SystemInterface::on_init(params) !=
       hardware_interface::CallbackReturn::SUCCESS) {
     return hardware_interface::CallbackReturn::ERROR;
   }


### PR DESCRIPTION
See https://github.com/ros-controls/ros2_control/pull/2323
needed for https://github.com/ros-controls/ros2_control/pull/2589

Please release it to kilted and rolling, thanks :)
Note: This API is not available on humble.